### PR TITLE
X11/GPU container support for containers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 [Open Container Initiative](https://opencontainers.org/) images for [Gazebo](https://gazebosim.org)!
 
+
 Are you looking for **Docker images**?
 You're in the right spot!
 OCI images are Docker images.
 [Here's how Docker and OCI relate](https://www.docker.com/blog/demystifying-open-container-initiative-oci-specifications/).
 
-> [!NOTE]  
+> [!NOTE]
 > This repository is mostly a fork of the work done by @slorezt in https://github.com/sloretz/ros_oci_images
 > adapted to Gazebo. All credit goes to Shane.
 
@@ -15,18 +16,19 @@ OCI images are Docker images.
 
 New to containers? Start with [Docker](https://docs.docker.com/get-docker/). It has the most documentation and tutorials.
 
-```bash
-docker run --rm=true -ti ghcr.io/j-rivero/gazebo:jetty-full gz sim --help
++```bash
++docker run --rm=true -ti -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw --runtime=nvidia \
+  -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all  \
+  ghcr.io/j-rivero/gazebo:jetty-full gz sim --verbose
 ```
 
 ## About the images
 
-All images are updated once per week at midnight GMT on Sunday. All images are based on Ubuntu.
+All images are updated once per week at midnight GMT on Sunday.
+Additionally each Gazebo release's images are updated automatically after a sync.
 
-The Gazebo releases provide different variants based on the included libraries:
-
-* core: gz libraries up to sdformat (including python bindings): gz-cmake. gz-math, gz-tools and gz-utils.
-* full: packages installed are based in the release metapackage (gz-${release})
+The Gazebo releases provide different variants based on the included libraries.
+All images are based on Ubuntu.
 
 | Image           | amd64 | arm64 v8 | Full Image Name                                |
 |-----------------|-------|----------|-----------------------------------------------|
@@ -45,75 +47,126 @@ The Gazebo releases provide different variants based on the included libraries:
 
 ## Using with other OCI compatible tools
 
-Used containers for a while?
-Other tools might be better fit your use case.
+Used containers for a while? Other tools might be a better fit for your use case. Below are examples showing how to run Gazebo with X11 display and GPU support using various container tools.
 
-[Apptainer](https://apptainer.org/)
+### [Apptainer](https://apptainer.org/)
+
+**GPU Support:** NVIDIA GPUs with `--nv` flag, AMD GPUs with `--rocm` flag
+**X11 Support:** Manual configuration required
 
 ```bash
+# Basic usage
 apptainer run docker://ghcr.io/j-rivero/gazebo:jetty-full gz sim --help
+
+# With NVIDIA GPU and X11 display
+apptainer run --nv --env DISPLAY=$DISPLAY -B /tmp/.X11-unix:/tmp/.X11-unix \
+  docker://ghcr.io/j-rivero/gazebo:jetty-full gz sim
 ```
 
-[Distrobox](https://github.com/89luca89/distrobox) (Requires Docker or Podman to be installed)
+[GPU Documentation](https://apptainer.org/docs/user/main/gpu.html)
+
+### [Distrobox](https://github.com/89luca89/distrobox)
+
+**Requirements:** Docker or Podman
+**GPU Support:** NVIDIA GPUs with `--nvidia` flag, Intel and AMD GPUs automatically supported
+**X11 Support:** Automatic X11 and Wayland socket access
 
 ```bash
-distrobox create --image ghcr.io/j-rivero/gazebo:jetty-full --name jetty-full
+# Create container with NVIDIA GPU support
+distrobox create --nvidia --image ghcr.io/j-rivero/gazebo:jetty-full --name jetty-full
+
+# Enter the container
 distrobox enter jetty-full
-gz sim --help
+
+# Run Gazebo (X11 and GPU work automatically)
+gz sim
 ```
 
-[nerdctl](https://github.com/containerd/nerdctl) using [rootless mode](https://github.com/containerd/nerdctl?tab=readme-ov-file#rootless-mode).
+[Documentation](https://github.com/89luca89/distrobox/blob/main/docs/useful_tips.md)
+
+### [nerdctl](https://github.com/containerd/nerdctl)
+
+**GPU Support:** Docker-compatible `--gpus` flag
+**X11 Support:** Manual configuration required
 
 ```bash
+# Basic usage
 nerdctl run --rm=true -ti ghcr.io/j-rivero/gazebo:jetty-full gz sim --help
+
+# With GPU and X11 display
+nerdctl run -it --rm --gpus all -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  ghcr.io/j-rivero/gazebo:jetty-full gz sim
 ```
 
-[Podman](https://podman.io/)
+[GPU Documentation](https://github.com/containerd/nerdctl/blob/main/docs/gpu.md)
+[Rootless Mode](https://github.com/containerd/nerdctl?tab=readme-ov-file#rootless-mode)
+
+### [Podman](https://podman.io/)
+
+**GPU Support:** NVIDIA GPUs using CDI with `--device nvidia.com/gpu=all` flag
+**X11 Support:** Manual configuration required with SELinux label disabled
 
 ```bash
+# Basic usage
 podman run --rm=true -ti ghcr.io/j-rivero/gazebo:jetty-full gz sim --help
+
+# With NVIDIA GPU and X11 display
+podman run -it --rm --device nvidia.com/gpu=all --security-opt=label=disable \
+  -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
+  ghcr.io/j-rivero/gazebo:jetty-full gz sim
 ```
 
-[Rocker](https://github.com/osrf/rocker) (requires Docker to be installed)
+[GPU Documentation](https://podman-desktop.io/docs/podman/gpu)
+
+### [Rocker](https://github.com/osrf/rocker)
+
+**Requirements:** Docker
+**GPU Support:** NVIDIA GPUs with `--nvidia` flag
+**X11 Support:** Automatic with `--x11` flag
 
 ```bash
+# Basic usage
 rocker ghcr.io/j-rivero/gazebo:jetty-full gz sim -- --help
+
+# With NVIDIA GPU and X11 display
+rocker --x11 --nvidia ghcr.io/j-rivero/gazebo:jetty-full gz sim
 ```
 
-[Sarus](https://sarus.readthedocs.io/en/stable/#)
+[Documentation](https://github.com/osrf/rocker)
+
+### [Sarus](https://sarus.readthedocs.io/en/stable/)
+
+**GPU Support:** NVIDIA GPUs through NVIDIA Container Toolkit (configured via OCI hooks)
+**X11 Support:** Manual bind mounting required
 
 ```bash
+# Pull and run basic usage
 sarus pull ghcr.io/j-rivero/gazebo:jetty-full
 sarus run -t ghcr.io/j-rivero/gazebo:jetty-full gz sim --help
+
+# With X11 display (GPU configured at system level)
+sarus run --mount=type=bind,source=/tmp/.X11-unix,destination=/tmp/.X11-unix \
+  ghcr.io/j-rivero/gazebo:jetty-full gz sim
 ```
 
-[SingularityCE](https://sylabs.io/singularity/)
+[GPU Documentation](https://sarus.readthedocs.io/en/stable/config/nvidia-container-toolkit.html)
+
+### [SingularityCE](https://sylabs.io/singularity/)
+
+**GPU Support:** NVIDIA GPUs with `--nv` flag, AMD GPUs with `--rocm` flag
+**X11 Support:** Manual configuration required
 
 ```bash
+# Basic usage
 singularity run docker://ghcr.io/j-rivero/gazebo:jetty-full gz sim --help
+
+# With NVIDIA GPU and X11 display
+singularity run --nv --env DISPLAY=$DISPLAY -B /tmp/.X11-unix:/tmp/.X11-unix \
+  docker://ghcr.io/j-rivero/gazebo:jetty-full gz sim
 ```
 
-[Toolbox](https://containertoolbx.org/) (Requires Podman to be installed)
-
-```bash
-toolbox create --image ghcr.io/j-rivero/gazebo:jetty-full jetty-full
-toolbox enter jetty-full
-gz sim --help
-```
-
-[x11docker](https://github.com/mviereck/x11docker) (Requires Podman, Docker, or nerdctl to be installed)
-
-```bash
-# Option 1: using podman
-podman pull ghcr.io/j-rivero/gazebo:jetty-full
-# Option 2: using docker
-docker pull ghcr.io/j-rivero/gazebo:jetty-full
-# Option 3: using nerdctl
-nerdctl pull ghcr.io/j-rivero/gazebo:jetty-full
-
-# After pulling, run this to use RViz with gpu acceleration
-x11docker --gpu ghcr.io/j-rivero/gazebo:jetty-full gz sim
-```
+[GPU Documentation](https://docs.sylabs.io/guides/latest/user-guide/gpu.html)
 
 ## Comparison to osrf/docker_images
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ OCI images are Docker images.
 
 ## Quick Start
 
-New to containers? Start with [Docker](https://docs.docker.com/get-docker/). It has the most documentation and tutorials.
+New to containers? Start with [Rocker](https://github.com/osrf/rocker) - it automatically handles GPU and display setup for you.
 
-+```bash
-+docker run --rm=true -ti -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw --runtime=nvidia \
-  -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all  \
-  ghcr.io/j-rivero/gazebo:jetty-full gz sim --verbose
+```bash
+# Install rocker (requires Docker)
+pip install rocker
+
+# Run Gazebo with GPU and X11 display support
+rocker --x11 --nvidia ghcr.io/j-rivero/gazebo:jetty-full gz sim
 ```
+
+For other container tools or advanced usage, see the sections below.
 
 ## About the images
 

--- a/scripts/is_new_version_available.py
+++ b/scripts/is_new_version_available.py
@@ -15,13 +15,16 @@
 # limitations under the License.
 
 import argparse
+import logging
 import subprocess
 
 
 def is_new_version_available(pkg):
     """Assumes apt-get update has already been called."""
     try:
-        subprocess.check_output(f"apt-cache depends {pkg}", shell=True, stderr=subprocess.DEVNULL)
+        subprocess.check_output(
+            f"apt-cache depends {pkg}", shell=True, stderr=subprocess.DEVNULL
+        )
     except subprocess.CalledProcessError:
         raise ValueError(f"Package '{pkg}' not found")
 
@@ -30,12 +33,14 @@ def is_new_version_available(pkg):
     cmd = f"apt-cache depends {pkg} | grep 'Depends:' | awk '{{print $2}}' | xargs apt list --upgradable 2>/dev/null"
     try:
         output = subprocess.check_output(cmd, shell=True)
-        output_lines = output.decode().strip().split('\n')
+        output_lines = output.decode().strip().split("\n")
         # Filter out the "Listing... Done" line and empty lines
-        upgradable_lines = [line for line in output_lines if line and not line.startswith('Listing')]
+        upgradable_lines = [
+            line for line in output_lines if line and not line.startswith("Listing")
+        ]
         return len(upgradable_lines) > 0
     except subprocess.CalledProcessError as e:
-        print(f"Error: Command failed with exit code {e.returncode}: {cmd}")
+        logging.error("Command failed with exit code %s: %s", e.returncode, cmd)
         raise
 
 

--- a/scripts/test_images.py
+++ b/scripts/test_images.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import logging
 import subprocess
 
 
@@ -26,7 +27,7 @@ def _full_name(registry, name, tag):
 def _pull(full_name, dry_run):
     cmd = ["docker", "pull", full_name]
     if dry_run:
-        print(cmd)
+        logging.info(cmd)
     else:
         subprocess.check_call(cmd)
 
@@ -39,13 +40,14 @@ def _run(full_name, extra_cmd, platform=None, dry_run=False):
     cmd.append(full_name)
     cmd.extend(extra_cmd)
     if dry_run:
-        print(cmd)
+        logging.info(cmd)
     else:
         subprocess.check_call(cmd)
 
 
-def _print_gz_help(full_name, platform=None, dry_run=False,
-                   gazebo_release="", image_type=""):
+def _print_gz_help(
+    full_name, platform=None, dry_run=False, gazebo_release="", image_type=""
+):
     cmd = []
     gz_subcmd = ["sim"]
 
@@ -80,6 +82,9 @@ def parse_arguments():
     args = parser.parse_args()
 
     return args
+
+
+logging.basicConfig(level=logging.INFO)
 
 
 def main():


### PR DESCRIPTION
This pull request significantly improves the `README.md` documentation to better guide users in running Gazebo containers with GPU and display support across a variety of OCI-compatible tools. The updates clarify the recommended starting point for new users, provide detailed usage instructions for multiple container runtimes, and enhance the overall structure and accessibility of the documentation.

**Major documentation improvements:**

* Recommends `rocker` as the preferred starting point for new users, emphasizing its automatic GPU and display setup, and provides updated installation and usage instructions.
* Expands and restructures the section on using Gazebo images with alternative OCI-compatible tools, adding detailed, tool-specific instructions (including GPU and X11 support), example commands, and links to relevant documentation for: Apptainer, Distrobox, nerdctl, Podman, Rocker, Sarus, and SingularityCE.