### PR TITLE
Update README with Rocker virtual environment recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,16 @@ OCI images are Docker images.
 
 ## Quick Start
 
-New to containers? Start with [Rocker](https://github.com/osrf/rocker) - it automatically handles GPU and display setup for you.
+New to containers? Start with [Rocker](https://github.com/osrf/rocker) - it automatically handles GPU and display setup for you. We recommend using Rocker inside of a Python [virtual environment.](https://docs.python.org/3/library/venv.html)  
 
 ```bash
 # Install rocker (requires Docker)
 pip install rocker
 
-# Run Gazebo with GPU and X11 display support
+# Gazebo with NVIDIA GPU support and X11 display support
+rocker --x11 --nvidia ghcr.io/j-rivero/gazebo:jetty-full gz sim
+
+# Gazebo without GPU Support
 rocker --x11 --nvidia ghcr.io/j-rivero/gazebo:jetty-full gz sim
 ```
 
@@ -131,7 +134,7 @@ podman run -it --rm --device nvidia.com/gpu=all --security-opt=label=disable \
 
 ```bash
 # Basic usage
-rocker ghcr.io/j-rivero/gazebo:jetty-full gz sim -- --help
+rocker -x11 ghcr.io/j-rivero/gazebo:jetty-full gz sim
 
 # With NVIDIA GPU and X11 display
 rocker --x11 --nvidia ghcr.io/j-rivero/gazebo:jetty-full gz sim


### PR DESCRIPTION
Added recommendation to use Rocker inside a Python virtual environment and clarified GPU support in commands.

*I could not get Gazebo to run with Rocker (I do not have an NVIDIA GPU on this machine).*

Here's the error messages I got:

```
(rocker-venv) kscottz@TheRatCage:~/code$ rocker --x11 ghcr.io/j-rivero/gazebo:jetty-full gz sim 
Active extensions ['x11']
Writing dockerfile to /tmp/tmprrkhccee/Dockerfile
vvvvvv
# Preamble from extension [x11]


FROM ghcr.io/j-rivero/gazebo:jetty-full
USER root
# Snippet from extension [x11]

# User Snippet from extension [x11]


^^^^^^
Building docker file with arguments:  {'path': '/tmp/tmprrkhccee', 'rm': True, 'nocache': False, 'pull': False}
building > Step 1/2 : FROM ghcr.io/j-rivero/gazebo:jetty-full
building >  ---> 668500efafe5
building > Step 2/2 : USER root
building >  ---> Using cache
building >  ---> 7d2dd52ef2aa
building > Successfully built 7d2dd52ef2aa
Executing command: 
docker run --rm -it  -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1   -e XAUTHORITY=/tmp/.docker7n7jfxcq.xauth -v /tmp/.docker7n7jfxcq.xauth:/tmp/.docker7n7jfxcq.xauth   -v /tmp/.X11-unix:/tmp/.X11-unix   -v /etc/localtime:/etc/localtime:ro  7d2dd52ef2aa gz sim
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
MESA: error: Failed to query drm device.
glx: failed to create dri3 screen
failed to load driver: iris
MESA: error: Failed to query drm device.
glx: failed to create dri3 screen
failed to load driver: iris
```

X11 seems to be working because I got the Gazebo startup screen (the one where it asks you to load a sim, I chose "Tugbot"). I also got this cheers message on my system:

<img width="499" height="141" alt="image" src="https://github.com/user-attachments/assets/1c78ce44-9090-4ab9-a091-2530e5649442" />

I took a look at the [TB4 Docker containers](https://github.com/kscottz/turtlebot4_docker/blob/main/README.md) and tried passing a similar set of commands, namely adding the `--devices=/dev/dri` flag. 

I got slightly farther along but Gazebo still hung. 

<img width="1295" height="1121" alt="image" src="https://github.com/user-attachments/assets/0ba58ffe-bbfc-493a-b90e-a4ae6cbffff9" />

I gave it a good couple of minutes thinking it was hung on asset downloading but it did not complete downloading after five minutes. 