### PR TITLE
Add server-only Jetty image variant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ This project uses **Earthly** (v0.8+) as the primary build tool, NOT traditional
 
 **Key Pattern:** Each Gazebo release has image variants:
 - `core` - Minimal install (gz-tools, libsdformat, python bindings)
-- `server-only` - Headless server without GUI/Qt dependencies (Jetty only: `gz-sim10-server`)
+- `server-only` - Headless server without GUI/Qt dependencies (currently Jetty only; see gazebo/Earthfile for the specific package)
 - `full` - Complete Gazebo suite (all gz-* packages)
 
 ### Multi-Architecture Support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ This project uses **Earthly** (v0.8+) as the primary build tool, NOT traditional
 
 ### Release-Specific Package Handling
 
-Each Gazebo release has different package names and Ubuntu base images. The logic in [gazebo/Earthfile](gazebo/Earthfile) lines 93-106 shows conditional package installation:
+Each Gazebo release has different package names and Ubuntu base images. The logic in the `gazebo-core` target in [gazebo/Earthfile](gazebo/Earthfile) shows conditional package installation:
 
 - **Fortress** (LTS): Ubuntu 22.04, uses `libignition-tools-dev` (legacy naming)
 - **Harmonic** (LTS): Ubuntu 22.04, `gz-tools2`, `libsdformat14-dev`
@@ -48,7 +48,7 @@ Each Gazebo release has different package names and Ubuntu base images. The logi
 
 ### Command Naming: ign vs gz
 
-Fortress uses the legacy `ign` command; all newer releases use `gz`. This affects testing in [scripts/test_images.py](scripts/test_images.py#L57-L61).
+Fortress uses the legacy `ign` command; all newer releases use `gz`. This affects testing in the `_print_gz_help` function in [scripts/test_images.py](scripts/test_images.py).
 
 ## Developer Workflows
 
@@ -132,7 +132,7 @@ This allows users to pin to exact build dates or track latest automatically.
 1. **Don't use `docker build`**: All image builds go through Earthly targets
 2. **Platform mismatch**: When testing locally, ensure QEMU is installed for cross-arch
 3. **Apt cache staleness**: `is_new_version_available.py` assumes `apt-get update` was already run
-4. **Hardcoded architectures**: Platform list appears in multiple places ([Earthfile](Earthfile) lines 29-46, [test_images.py](scripts/test_images.py#L92-L98))
+4. **Hardcoded architectures**: Platform list appears in multiple places ([Earthfile](Earthfile), `combos` list in [test_images.py](scripts/test_images.py))
 5. **GPU testing**: Images are built for GPU support but CI only validates basic command execution
 
 ## Quick Reference Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,9 @@ This project uses **Earthly** (v0.8+) as the primary build tool, NOT traditional
 └── lib/Earthfile                     # SAVE_IMAGE_AND_DATE function for tagging & pushing
 ```
 
-**Key Pattern:** Each Gazebo release has TWO image variants:
+**Key Pattern:** Each Gazebo release has image variants:
 - `core` - Minimal install (gz-tools, libsdformat, python bindings)
+- `server-only` - Headless server without GUI/Qt dependencies (Jetty only: `gz-sim10-server`)
 - `full` - Complete Gazebo suite (all gz-* packages)
 
 ### Multi-Architecture Support

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All images are based on Ubuntu.
 |-----------------|-------|----------|-----------------------------------------------|
 | **[Gazebo Jetty (LTS)](https://gazebosim.org/docs/jetty)** | | | |
 | core            | ✅     | ✅        | `ghcr.io/openrobotics/gazebo:jetty-core`           |
+| server-only     | ✅     | ✅        | `ghcr.io/openrobotics/gazebo:jetty-server-only`    |
 | full            | ✅     | ✅        | `ghcr.io/openrobotics/gazebo:jetty-full`           |
 | **[Gazebo Ionic](https://gazebosim.org/docs/ionic)** | | | |
 | core            | ✅     | ✅        | `ghcr.io/openrobotics/gazebo:ionic-core`           |

--- a/gazebo/Earthfile
+++ b/gazebo/Earthfile
@@ -55,6 +55,12 @@ GAZEBO_BINARY_IMAGES:
     FROM --pass-args +gazebo-core
     DO lib+SAVE_IMAGE_AND_DATE --fully_qualified_name=${registry}${image_name}:${GAZEBO_RELEASE}-core
 
+    # gazebo-server-only (only for releases that have it)
+    IF [ "$GAZEBO_RELEASE" = "jetty" ]
+        FROM --pass-args +gazebo-server-only
+        DO lib+SAVE_IMAGE_AND_DATE --fully_qualified_name=${registry}${image_name}:${GAZEBO_RELEASE}-server-only
+    END
+
     # gazebo-full
     FROM --pass-args +gazebo-full
     DO lib+SAVE_IMAGE_AND_DATE --fully_qualified_name=${registry}${image_name}:${GAZEBO_RELEASE}-full
@@ -108,6 +114,16 @@ gazebo-core:
     CMD ["bash"]
 
     SAVE IMAGE localhost/gazebo-intermediate:${GAZEBO_RELEASE}-core
+
+
+gazebo-server-only:
+    ARG GAZEBO_RELEASE
+    FROM --pass-args +gazebo-core
+
+    # Install Gazebo server-only package (no GUI/Qt dependencies)
+    DO apt+INSTALL --packages=gz-sim10-server
+
+    SAVE IMAGE localhost/gazebo-intermediate:${GAZEBO_RELEASE}-server-only
 
 
 gazebo-full:

--- a/gazebo/Earthfile
+++ b/gazebo/Earthfile
@@ -120,7 +120,8 @@ gazebo-server-only:
     ARG GAZEBO_RELEASE
     FROM --pass-args +gazebo-core
 
-    # Install Gazebo server-only package (no GUI/Qt dependencies)
+    # Install Gazebo server-only package (no GUI/Qt dependencies).
+    # gz-sim10-server is Jetty-specific; update package name for future releases.
     DO apt+INSTALL --packages=gz-sim10-server
 
     SAVE IMAGE localhost/gazebo-intermediate:${GAZEBO_RELEASE}-server-only

--- a/scripts/test_images.py
+++ b/scripts/test_images.py
@@ -60,9 +60,16 @@ def _print_gz_help(
     if image_type == "core":
         cmd += ["sdf"]
     elif image_type == "server-only":
+        # Invoke the server binary directly (not through the gz CLI wrapper).
+        # sim10 path is Jetty-specific; update for future releases.
         cmd = ["/usr/libexec/gz/sim10/gz-sim-server"]
     elif image_type == "full":
         cmd += gz_subcmd
+    else:
+        raise ValueError(
+            f"Unknown image_type '{image_type}' for release '{gazebo_release}'. "
+            f"Add handling for this variant in _print_gz_help()."
+        )
 
     cmd += ["--help"]
 
@@ -111,7 +118,10 @@ def main():
         ]
     for image, platform in combos:
         tag = f"{gazebo_release}-{image}"
-        package = f"gz-{gazebo_release}"
+        if image == "server-only":
+            package = "gz-sim10-server"
+        else:
+            package = f"gz-{gazebo_release}"
         full_name = _full_name(args.registry, args.image_name, tag)
         _pull(full_name, dry_run)
         _print_pkg_version(full_name, package, platform, args.dry_run)

--- a/scripts/test_images.py
+++ b/scripts/test_images.py
@@ -59,6 +59,8 @@ def _print_gz_help(
 
     if image_type == "core":
         cmd += ["sdf"]
+    elif image_type == "server-only":
+        cmd = ["/usr/libexec/gz/sim10/gz-sim-server"]
     elif image_type == "full":
         cmd += gz_subcmd
 
@@ -102,6 +104,11 @@ def main():
         ("core", arm64),
         ("full", arm64),
     ]
+    if gazebo_release == "jetty":
+        combos += [
+            ("server-only", amd64),
+            ("server-only", arm64),
+        ]
     for image, platform in combos:
         tag = f"{gazebo_release}-{image}"
         package = f"gz-{gazebo_release}"


### PR DESCRIPTION
This pull request introduces a new "server-only" Docker image variant for the Gazebo Jetty release, updates documentation to reflect this addition, and ensures that build and test scripts properly handle the new variant as described in https://discourse.openrobotics.org/t/gazebo-jetty-server-only-installation-for-ubuntu/53375

**Gazebo Jetty "server-only" image support:**

* Added a new `gazebo-server-only` Earthly build target in `gazebo/Earthfile`, which installs only the headless server package (`gz-sim10-server`) without GUI/Qt dependencies, and saves the resulting image as a Jetty-specific variant.
* Updated the main build target to build and push the new `server-only` image for Jetty releases.

**Testing and validation updates:**

* Modified `scripts/test_images.py` to recognize and test the `server-only` image type: adds support for the new variant in the image/platform matrix, and invokes the correct binary for validation. Raises an error if an unknown image type is encountered. [[1]](diffhunk://#diff-06db448e49965d9fb50b2d447e2771d0c8e12deeb26ce5a206259faf92aec8faR62-R72) [[2]](diffhunk://#diff-06db448e49965d9fb50b2d447e2771d0c8e12deeb26ce5a206259faf92aec8faR114-R123)

**Documentation improvements:**

* Updated `README.md` and `AGENTS.md` to document the new `server-only` image variant, clarify image variant patterns, and improve references to code locations and package handling logic. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L25-R27) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L39-R40) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L50-R51) [[5]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L134-R135)