### PR TITLE
Fix rotary: restrict to amd64 only

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -42,7 +42,7 @@ jetty-multiarch:
 rotary-multiarch:
     ARG registry='localhost/'
     ARG image_name='gazebo'
-    BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64/v8 +rotary
+    BUILD --pass-args --platform=linux/amd64 +rotary
 
 
 ionic-multiarch:

--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ All images are based on Ubuntu.
 | full            | ✅     | ✅        | `ghcr.io/openrobotics/gazebo:fortress-full`        |
 | **Rolling / Nightly** | | | |
 | **Gazebo Rotary** | | | |
-| core            | ✅     | ✅        | `ghcr.io/openrobotics/gazebo:rotary-core`          |
-| full            | ✅     | ✅        | `ghcr.io/openrobotics/gazebo:rotary-full`          |
+| core            | ✅     | ❌        | `ghcr.io/openrobotics/gazebo:rotary-core`          |
+| full            | ✅     | ❌        | `ghcr.io/openrobotics/gazebo:rotary-full`          |
+
+
+> [!NOTE]
+> Rotary images are currently published for amd64 only because the required arm64 packages are not generated for rotary
 
 
 ## Using with other OCI compatible tools

--- a/scripts/test_images.py
+++ b/scripts/test_images.py
@@ -96,26 +96,31 @@ def parse_arguments():
 logging.basicConfig(level=logging.INFO)
 
 
+def _image_platform_combos(gazebo_release):
+    amd64 = "linux/amd64"
+    arm64 = "linux/arm64/v8"
+
+    # Rotary packages are not available on arm64, so its images are amd64-only.
+    platforms = [amd64] if gazebo_release == "rotary" else [amd64, arm64]
+
+    combos = []
+    for platform in platforms:
+        combos.extend([("core", platform), ("full", platform)])
+
+    if gazebo_release == "jetty":
+        for platform in platforms:
+            combos.append(("server-only", platform))
+
+    return combos
+
+
 def main():
     args = parse_arguments()
 
     gazebo_release = args.release.lower()
     dry_run = args.dry_run
 
-    amd64 = "linux/amd64"
-    arm64 = "linux/arm64/v8"
-
-    combos = [
-        ("core", amd64),
-        ("full", amd64),
-        ("core", arm64),
-        ("full", arm64),
-    ]
-    if gazebo_release == "jetty":
-        combos += [
-            ("server-only", amd64),
-            ("server-only", arm64),
-        ]
+    combos = _image_platform_combos(gazebo_release)
     for image, platform in combos:
         tag = f"{gazebo_release}-{image}"
         if image == "server-only":


### PR DESCRIPTION
Earthfile no longer requests linux/arm64/v8 for +rotary-multiarch, scripts/test_images.py now selects platforms per release so Rotary skips arm64 while the other releases keep their existing coverage, and README.md marks Rotary arm64 as unavailable with a note explaining the nightly-package limitation.

Generated-by: GPT-5.4